### PR TITLE
Format the version schema like rails does since 5.2

### DIFF
--- a/lib/merge_db_schema/main.rb
+++ b/lib/merge_db_schema/main.rb
@@ -30,9 +30,16 @@ module MergeDBSchema
 
       def update_version(path, version)
         text = path.read
-        text[RE_DEFINE, 1] = version.to_s
+        text[RE_DEFINE, 1] = formatted_version(version)
         path.write(text)
       end
+
+      def formatted_version(version)
+        stringified = version.to_s
+        return stringified unless stringified.length == 14
+        stringified.insert(4, "_").insert(7, "_").insert(10, "_")
+      end
+
     end
   end
 end

--- a/test/data/simple/expected.rb
+++ b/test/data/simple/expected.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170628094212) do
+ActiveRecord::Schema.define(version: 2017_06_28_094212) do
 
   create_table "articles", force: :cascade do |t|
     t.string "title"

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -80,13 +80,13 @@ class TestMain < Minitest::Test
       sh! 'git', 'branch', 'change2-original'
       ex = assert_raises{sh! 'git', 'merge', '--no-edit', 'change1'}
       assert ex.is_a?(CommandExecutionError)
-      assert_match(/version: 20170701093311/, db_schema.read)
+      assert_match(/version: 2017_07_01_093311/, db_schema.read)
       sh! 'git', 'merge', '--abort'
 
       sh! 'git', 'checkout', 'change1'
       ex = assert_raises{sh! 'git', 'merge', '--no-edit', 'change2-original'}
       assert ex.is_a?(CommandExecutionError)
-      assert_match(/version: 20170701093311/, db_schema.read)
+      assert_match(/version: 2017_07_01_093311/, db_schema.read)
     end
   ensure
     ENV['PATH'] = original_path

--- a/test/test_main.rb
+++ b/test/test_main.rb
@@ -75,7 +75,7 @@ class TestMain < Minitest::Test
     assert current.read != current_original.read
     assert_equal current.read, expected.read
 
-    assert_match(/version: 20170628094212/, current.read)
+    assert_match(/version: 2017_06_28_094212/, current.read)
     refute current.read.match(/\={7,}/)
     refute current.read.match(/\<{7,}/)
     refute current.read.match(/\>{7,}/)
@@ -87,7 +87,7 @@ class TestMain < Minitest::Test
   def assert_conflict(current, current_original, expected)
     assert current.read != current_original.read
 
-    assert_match(/version: 20170701093311/, current.read)
+    assert_match(/version: 2017_07_01_093311/, current.read)
     assert current.read.match(/\={7,}/)
     assert current.read.match(/\<{7,}/)
     assert current.read.match(/\>{7,}/)


### PR DESCRIPTION
It adds an underscore to separate year, month, day, time.

See https://github.com/rails/rails/commit/bb13c37fefdc8b5699918b38eff84751c2899ad5